### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/src/runtime/composables/useSnipcart.ts
+++ b/src/runtime/composables/useSnipcart.ts
@@ -1,4 +1,4 @@
-import { useNuxtApp, useState } from "#app"
+import { useNuxtApp, useState } from "#imports"
 import { watch } from "vue"
 import cloneDeep from "lodash-es/cloneDeep"
 import { SnipcartSDK } from "../../types"

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 import { ModuleOptions } from '../module';
 import { useSnipcart } from './composables/useSnipcart';
 


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.